### PR TITLE
Create .gitattributes to fix line endings on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto
+*.sh text eol=lf


### PR DESCRIPTION
This is a simple, non-intrusive way to fix provision.sh file not working on Windows. Without this, it complains similar to this: line 1: $' :\r': command not found"?