### PR TITLE
fix: Use v4 signature for s3 file uploads

### DIFF
--- a/build/COPY_ROOT/opt/serverless/utils/s3utils.py
+++ b/build/COPY_ROOT/opt/serverless/utils/s3utils.py
@@ -13,7 +13,8 @@ class s3utils:
             connect_timeout=self.connect_timeout, 
             retries = dict(
                 max_attempts = self.connect_attempts
-            )
+            ),
+            signature_version = 'v4'
         )
         self.session = boto3.session.Session(
             aws_access_key_id = self.aws_access_key_id,


### PR DESCRIPTION
I encountered UnauthorizedAccess errors while downloading files using presigned URLs from Backblaze. It appears that generated URLs were utilizing the v2 signature (more info here: https://www.reddit.com/r/backblaze/comments/xdvnb8/cannot_get_upload_to_presigned_url_to_work/).
After explicitly setting the v4 signature version, presigned URLs are now functioning as intended