### PR TITLE
feat: Add webhook url and extra params for serverless API

### DIFF
--- a/build/COPY_ROOT/opt/serverless/docs/example_payloads/bound_image2image.json
+++ b/build/COPY_ROOT/opt/serverless/docs/example_payloads/bound_image2image.json
@@ -5,6 +5,8 @@
         "aws_secret_access_key": "your-s3-secret-access-key",
         "aws_endpoint_url": "https://my-endpoint.backblaze.com",
         "aws_bucket_name": "your-bucket",
+        "webhook_url": "your-webhook-url",
+        "webhook_extra_params": {},
         "ckpt_name": "v1-5-pruned-emaonly.ckpt",
         "include_text": "photograph of a victorian woman, arms outstretched with angel wings. cloudy sky, meadow grass",
         "exclude_text": "watermark, text",

--- a/build/COPY_ROOT/opt/serverless/docs/example_payloads/bound_text2image.json
+++ b/build/COPY_ROOT/opt/serverless/docs/example_payloads/bound_text2image.json
@@ -5,6 +5,8 @@
         "aws_secret_access_key": "your-s3-secret-access-key",
         "aws_endpoint_url": "https://my-endpoint.backblaze.com",
         "aws_bucket_name": "your-bucket",
+        "webhook_url": "your-webhook-url",
+        "webhook_extra_params": {},
         "steps": 20,
         "ckpt_name": "v1-5-pruned-emaonly.ckpt",
         "sampler_name": "euler",

--- a/build/COPY_ROOT/opt/serverless/docs/example_payloads/raw_controlnet_t2i_adapters.json
+++ b/build/COPY_ROOT/opt/serverless/docs/example_payloads/raw_controlnet_t2i_adapters.json
@@ -5,6 +5,8 @@
         "aws_secret_access_key": "your-s3-secret-access-key",
         "aws_endpoint_url": "https://my-endpoint.backblaze.com",
         "aws_bucket_name": "your-bucket",
+        "webhook_url": "your-webhook-url",
+        "webhook_extra_params": {},
         "workflow_json": {
             "3": {
               "inputs": {

--- a/build/COPY_ROOT/opt/serverless/docs/example_payloads/raw_image2image.json
+++ b/build/COPY_ROOT/opt/serverless/docs/example_payloads/raw_image2image.json
@@ -5,6 +5,8 @@
         "aws_secret_access_key": "your-s3-secret-access-key",
         "aws_endpoint_url": "https://my-endpoint.backblaze.com",
         "aws_bucket_name": "your-bucket",
+        "webhook_url": "your-webhook-url",
+        "webhook_extra_params": {},
         "workflow_json": {
             "3": {
               "inputs": {

--- a/build/COPY_ROOT/opt/serverless/docs/example_payloads/raw_text2image.json
+++ b/build/COPY_ROOT/opt/serverless/docs/example_payloads/raw_text2image.json
@@ -5,6 +5,8 @@
         "aws_secret_access_key": "your-s3-secret-access-key",
         "aws_endpoint_url": "https://my-endpoint.backblaze.com",
         "aws_bucket_name": "your-bucket",
+        "webhook_url": "your-webhook-url",
+        "webhook_extra_params": {},
         "workflow_json": {
             "3": {
               "inputs": {

--- a/build/COPY_ROOT/opt/serverless/docs/example_payloads/raw_upscale.json
+++ b/build/COPY_ROOT/opt/serverless/docs/example_payloads/raw_upscale.json
@@ -5,6 +5,8 @@
         "aws_secret_access_key": "your-s3-secret-access-key",
         "aws_endpoint_url": "https://my-endpoint.backblaze.com",
         "aws_bucket_name": "your-bucket",
+        "webhook_url": "your-webhook-url",
+        "webhook_extra_params": {},
         "workflow_json": {
             "3": {
               "inputs": {

--- a/build/COPY_ROOT/opt/serverless/docs/swagger/openapi.yaml
+++ b/build/COPY_ROOT/opt/serverless/docs/swagger/openapi.yaml
@@ -42,6 +42,14 @@ components:
                             type: string
                             required: false
                             description: Alternatively set AWS_BUCKET_NAME environment variable
+                        webhook_url:
+                            type: string
+                            required: false
+                            description: Webhook URL to invoke after a successful run or an error. Alternatively set WEBHOOK_URL environment variable
+                        webhook_extra_params:
+                            type: object
+                            required: false
+                            description: Extra params for webhook request
         RawWorkflow:
             description: Downloads URLs to input directory with no additional processing - Your application must modify the workflow as needed.
             allOf:

--- a/build/COPY_ROOT/opt/serverless/handlers/image2image.py
+++ b/build/COPY_ROOT/opt/serverless/handlers/image2image.py
@@ -61,6 +61,8 @@ Example Request Body:
         "aws_secret_access_key": "your-s3-secret-access-key",
         "aws_endpoint_url": "https://my-endpoint.backblaze.com",
         "aws_bucket_name": "your-bucket",
+        "webhook_url": "your-webhook-url",
+        "webhook_extra_params": {},
         "ckpt_name": "v1-5-pruned-emaonly.ckpt",
         "include_text": "photograph of a victorian woman, arms outstretched with angel wings. cloudy sky, meadow grass",
         "exclude_text": "watermark, text",

--- a/build/COPY_ROOT/opt/serverless/handlers/rawworkflow.py
+++ b/build/COPY_ROOT/opt/serverless/handlers/rawworkflow.py
@@ -34,6 +34,8 @@ Example Request Body:
         "aws_secret_access_key": "your-s3-secret-access-key",
         "aws_endpoint_url": "https://my-endpoint.backblaze.com",
         "aws_bucket_name": "your-bucket",
+        "webhook_url": "your-webhook-url",
+        "webhook_extra_params": {},
         "workflow_json": {
             "3": {
               "inputs": {

--- a/build/COPY_ROOT/opt/serverless/handlers/text2image.py
+++ b/build/COPY_ROOT/opt/serverless/handlers/text2image.py
@@ -65,6 +65,8 @@ Example Request Body:
         "aws_secret_access_key": "your-s3-secret-access-key",
         "aws_endpoint_url": "https://my-endpoint.backblaze.com",
         "aws_bucket_name": "your-bucket",
+        "webhook_url": "your-webhook-url",
+        "webhook_extra_params": {},
         "steps": 20,
         "ckpt_name": "v1-5-pruned-emaonly.ckpt",
         "sampler_name": "euler",

--- a/build/COPY_ROOT/opt/serverless/providers/runpod/test_input.json
+++ b/build/COPY_ROOT/opt/serverless/providers/runpod/test_input.json
@@ -5,6 +5,8 @@
         "aws_secret_access_key": "your-s3-secret-access-key",
         "aws_endpoint_url": "https://my-endpoint.backblaze.com",
         "aws_bucket_name": "your-bucket",
+        "webhook_url": "your-webhook-url",
+        "webhook_extra_params": {},
         "workflow_json": {
             "3": {
               "inputs": {

--- a/build/COPY_ROOT/opt/serverless/utils/network.py
+++ b/build/COPY_ROOT/opt/serverless/utils/network.py
@@ -36,3 +36,13 @@ class Network:
 
         print(f"Downloaded {url} to {filepath}")
         return filepath
+    
+    @staticmethod
+    def invoke_webhook(url, data):
+        try:
+            response = requests.post(url, json=data)
+            print(f"Invoke webhook {url} with data {data} - status {response.status_code}")
+            return response
+        except requests.exceptions.RequestException as e:
+            print(f"Error making POST request: {e}")
+            return None


### PR DESCRIPTION
I've implemented the option to trigger a webhook upon the successful execution of a serverless run or in the case of an error. Additional parameters are also supported, such as a user ID or other relevant information. The webhook URL can be configured either within the request itself or by using the `WEBHOOK_URL` environment variable.