### PR TITLE
Ensures node requirements are installed independently of AUTO_UPDATE

### DIFF
--- a/config/provisioning/default.sh
+++ b/config/provisioning/default.sh
@@ -93,9 +93,11 @@ function provisioning_get_nodes() {
             if [[ ${AUTO_UPDATE,,} != "false" ]]; then
                 printf "Updating node: %s...\n" "${repo}"
                 ( cd "$path" && git pull )
-                if [[ -e $requirements ]]; then
-                    micromamba -n comfyui run ${PIP_INSTALL} -r "$requirements"
-                fi
+            fi
+
+            printf "Ensuring node requirements: %s...\n" "${repo}"
+            if [[ -e $requirements ]]; then
+                micromamba -n comfyui run ${PIP_INSTALL} -r "$requirements"
             fi
         else
             printf "Downloading node: %s...\n" "${repo}"


### PR DESCRIPTION
Only runs git pull when AUTO_UPDATE is set, otherwise, installs all requirements.

(Still WIP, working on testing the fix)

Fixes #68